### PR TITLE
YearProfit : impl multi-variable items in one Td

### DIFF
--- a/src/com/gtk/msfinance/Main.java
+++ b/src/com/gtk/msfinance/Main.java
@@ -31,6 +31,8 @@ public class Main {
 //		listStock.add(new Stock("계양전기","012200"));
 		int stocksSize = listStock.size();
 		for(int i = 0; i < stocksSize; i++) {
+			if(i<23)
+				continue;
 			Stock stock = listStock.get(i);
 			
 			stock.updateYearReport();


### PR DESCRIPTION
implementation support below HTML using jsoup.
how : get index of year profit of "영업이익" contains td, and then get real Year Profit using getted index.

Elements0.
<td width="209" height="227" valign="TOP">[매출액]<br>[영업이익(영업손실)]<br>[계속영업당기순이익(손실)]<br>[중단영업당기순이익(손실)]<br>[당기순이익(당기순손실)]<br>지배기업소유주지분 순이익<br>비지배지분 순이익<br>총포괄손익<br>기본주당순이익<br>희석주당순이익</td>

Elements1.(using jsoup's element.nextSibling)
<td width="144" height="227" align="RIGHT"><span>41,536<br>1,559<br>2,870<br>-<br></span><span>2,835</span><span><br></span><span>2,835</span><span><br>-<br>2,804<br>26원<br>26원</span><br>
</td>